### PR TITLE
PR for Refactor shutdown sequence to use plugin.stop

### DIFF
--- a/logstash-input-snmptrap.gemspec
+++ b/logstash-input-snmptrap.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot"
 
   s.add_runtime_dependency 'snmp'
+  s.add_runtime_dependency 'logstash-codec-plain'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/inputs/snmptrap_spec.rb
+++ b/spec/inputs/snmptrap_spec.rb
@@ -1,1 +1,12 @@
 require "logstash/devutils/rspec/spec_helper"
+require 'logstash/inputs/snmptrap'
+
+describe LogStash::Inputs::Snmptrap do
+  it_behaves_like "an interruptible input plugin" do
+    # as there is no mocking the run method will
+    # raise a connection error and put the run method
+    # into the sleep retry section loop
+    # meaning that the stoppable sleep impl is tested
+    let(:config) { {} }
+  end
+end


### PR DESCRIPTION
add it_behaves_like "an interruptible input plugin" shared example
refactor plugin slightly according to elastic/logstash#3210

Depends on elastic/logstash-devutils#32 and elastic/logstash#3812

Fixes #11 