### PR TITLE
When stopping, ignore exceptions from SNMP::TrapListener's process_traps

### DIFF
--- a/lib/logstash/inputs/snmptrap.rb
+++ b/lib/logstash/inputs/snmptrap.rb
@@ -3,6 +3,7 @@ require "logstash/inputs/base"
 require "logstash/namespace"
 
 require "snmp"
+require_relative "snmptrap/patches/trap_listener"
 
 # Read snmp trap messages as events
 #

--- a/lib/logstash/inputs/snmptrap/patches/trap_listener.rb
+++ b/lib/logstash/inputs/snmptrap/patches/trap_listener.rb
@@ -1,0 +1,22 @@
+require "snmp"
+
+# Patch SNMP::TrapListener#process_traps to ignore exceptions when stopping.
+class SNMP::TrapListener
+  alias_method :original_exit, :exit
+  def exit
+    @stop = true
+    original_exit
+  end
+
+  def stop?
+    @stop
+  end
+
+  alias_method :original_process_traps, :process_traps
+  def process_traps(*args)
+    original_process_traps(*args)
+  rescue
+    raise unless stop?
+  end
+end
+


### PR DESCRIPTION
This is a patch to work around a problem that appears like this:

* snmptrap input plugin is running
* snmp lib runs trap IO on a separate thread
* input plugin is told to stop
* TrapListener#exit is called and closes the socket
* an active+blocked socket.recvfrom() is interrupted throwing IOError
* rspec test fails as a result.

Fixes #23
