### PR TITLE
Binary to Hex string conversion where values are not ASCII

### DIFF
--- a/logstash-input-snmptrap.gemspec
+++ b/logstash-input-snmptrap.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 6.99"
 
   s.add_runtime_dependency 'snmp'
   s.add_runtime_dependency 'logstash-codec-plain'

--- a/logstash-input-snmptrap.gemspec
+++ b/logstash-input-snmptrap.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 6.99"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'snmp'
   s.add_runtime_dependency 'logstash-codec-plain'


### PR DESCRIPTION
-  Transformed all binary field values to hex character strings separated by ':', data can be afterwards altered to another format if required  

- https://github.com/logstash-plugins/logstash-input-snmptrap/issues/8
- https://github.com/logstash-plugins/logstash-input-snmptrap/issues/7
