### PR TITLE
Feat: ecs_compatiblity support + (optional) target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Feat: ecs_compatiblity support + (optional) target [#37](https://github.com/logstash-plugins/logstash-input-snmptrap/pull/37)
+
 ## 3.0.6
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -78,7 +78,7 @@ SNMP Community String to listen for.
   * Value type is <<string,string>>
   * Supported values are:
     ** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
-    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, JMS specific properties)
+    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, the `host` field)
   * Default value depends on which version of Logstash is running:
    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
    ** Otherwise, the default value is `disabled`.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,7 +23,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 Read snmp trap messages as events
 
-Resulting `message` field looks like :
+Resulting `message` field resembles:
 [source,ruby]
   #<SNMP::SNMPv1_Trap:0x6f1a7a4 @varbind_list=[#<SNMP::VarBind:0x2d7bcd8f @value="teststring",
   @name=[1.11.12.13.14.15]>], @timestamp=#<SNMP::TimeTicks:0x1af47e9d @value=55>, @generic_trap=6,

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,13 +23,24 @@ include::{include_path}/plugin_header.asciidoc[]
 
 Read snmp trap messages as events
 
-Resulting `@message` looks like :
+Resulting `message` field looks like :
 [source,ruby]
   #<SNMP::SNMPv1_Trap:0x6f1a7a4 @varbind_list=[#<SNMP::VarBind:0x2d7bcd8f @value="teststring",
   @name=[1.11.12.13.14.15]>], @timestamp=#<SNMP::TimeTicks:0x1af47e9d @value=55>, @generic_trap=6,
   @enterprise=[1.2.3.4.5.6], @source_ip="127.0.0.1", @agent_addr=#<SNMP::IpAddress:0x29a4833e @value="\xC0\xC1\xC2\xC3">,
   @specific_trap=99>
 
+
+==== Compatibility with the Elastic Common Schema (ECS)
+
+Because SNMP data has specific field names based on OIDs, we recommend setting a <<plugins-{type}s-{plugin}-target>>.
+The source host field changes based on <<plugins-{type}s-{plugin}-ecs_compatibility>>.
+
+[cols="<l,<l,e,<e"]
+|=======================================================================
+|ECS disabled |ECS v1, v8    |Description
+|[host]       |[host][ip]    |IP address of the host e.g. "192.168.1.11"
+|=======================================================================
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Snmptrap Input Configuration Options
@@ -40,8 +51,10 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-community>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-yamlmibdir>> |<<string,string>>|No
 |=======================================================================
 
@@ -57,6 +70,19 @@ input plugins.
   * Default value is `"public"`
 
 SNMP Community String to listen for.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
+    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, JMS specific properties)
+  * Default value depends on which version of Logstash is running:
+   ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+   ** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-host"]
 ===== `host` 
@@ -74,6 +100,17 @@ The address to listen on
 
 The port to listen on. Remember that ports less than 1024 (privileged
 ports) may require root to use. hence the default of 1062.
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting
+
+The name of the field under which SNMP payloads are assigned.
+If not specified data will be stored in the root of the event.
+
+Setting a target is recommended when <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled.
 
 [id="plugins-{type}s-{plugin}-yamlmibdir"]
 ===== `yamlmibdir` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -31,6 +31,7 @@ Resulting `message` field looks like :
   @specific_trap=99>
 
 
+[id="plugins-{type}s-{plugin}-ecs"]
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 Because SNMP data has specific field names based on OIDs, we recommend setting a <<plugins-{type}s-{plugin}-target>>.

--- a/lib/logstash/inputs/snmptrap.rb
+++ b/lib/logstash/inputs/snmptrap.rb
@@ -109,7 +109,7 @@ class LogStash::Inputs::Snmptrap < LogStash::Inputs::Base
   end # def snmptrap_listener
 
   def process_trap(trap)
-    @logger.debug? && @logger.debug("SNMP Trap received: ", :trap_object => trap)
+    @logger.debug? && @logger.debug("SNMP Trap received: ", :trap_object => trap.inspect)
 
     data = Hash.new
     trap.each_varbind do |vb|

--- a/lib/logstash/inputs/snmptrap.rb
+++ b/lib/logstash/inputs/snmptrap.rb
@@ -116,7 +116,7 @@ class LogStash::Inputs::Snmptrap < LogStash::Inputs::Base
       data[vb.name.to_s] = vb.value.to_s
     end
     event = targeted_event_factory.new_event(data)
-    event.set(@host_ip_field, trap.source_ip)
+    event.set(@host_ip_field, trap.source_ip) if trap.source_ip
     event.set('message', trap.inspect)
     decorate(event)
     event

--- a/logstash-input-snmptrap.gemspec
+++ b/logstash-input-snmptrap.gemspec
@@ -21,9 +21,10 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-
-  s.add_runtime_dependency 'snmp'
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'snmp'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-input-snmptrap.gemspec
+++ b/logstash-input-snmptrap.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-codec-plain'

--- a/logstash-input-snmptrap.gemspec
+++ b/logstash-input-snmptrap.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-snmptrap'
-  s.version         = '3.0.6'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Creates events based on SNMP trap messages"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/snmptrap_spec.rb
+++ b/spec/inputs/snmptrap_spec.rb
@@ -3,6 +3,7 @@ require "logstash/devutils/rspec/shared_examples"
 require 'logstash/inputs/snmptrap'
 
 describe LogStash::Inputs::Snmptrap do
+
   it_behaves_like "an interruptible input plugin" do
     # as there is no mocking the run method will
     # raise a connection error and put the run method
@@ -10,4 +11,61 @@ describe LogStash::Inputs::Snmptrap do
     # meaning that the stoppable sleep impl is tested
     let(:config) { {} }
   end
+
+  let(:config) { Hash.new }
+
+  subject(:input) { described_class.new(config) }
+
+  let(:source_ip) { '192.168.1.11' }
+
+  let(:snmp_manager) do
+    manager = SNMP::Manager.new(:host => 'localhost', :port => 1061)
+    def manager.send_request(trap, community, host, port)
+      trap
+    end
+    manager
+  end
+
+  context 'v1' do
+
+    let(:trap) do
+      trap = snmp_manager.trap_v1("enterprises.9", "10.1.2.3", :enterpriseSpecific, 42, 12345,
+                                  [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(111))])
+      trap.source_ip = source_ip
+      trap
+    end
+
+    before { @event = input.send :process_trap, trap }
+
+    it "extract snmp payload" do
+      expect( @event.get('1.3.6.1.2.3.4') ).to eql '111'
+    end
+
+    it "sets source host" do
+      expect( @event.get('host') ).to eql '192.168.1.11'
+    end
+
+  end
+
+  context 'v2' do
+
+    let(:trap) do
+      trap = snmp_manager.trap_v2(1011, "1.3.6.1.2.1.1.1.0", ["1.2.3", "1.4.5.6"])
+      trap.source_ip = '192.168.1.11'
+      trap
+    end
+
+    before { @event = input.send :process_trap, trap }
+
+    it "extract snmp payload" do
+      expect( @event.get('1.2.3') ).to eql 'Null'
+      expect( @event.get('1.3.6.1.2.1.1.3.0') ).to eql '00:00:10.11' # uptime tick
+    end
+
+    it "sets source host" do
+      expect( @event.get('host') ).to eql '192.168.1.11'
+    end
+
+  end
+
 end

--- a/spec/inputs/snmptrap_spec.rb
+++ b/spec/inputs/snmptrap_spec.rb
@@ -38,6 +38,8 @@ describe LogStash::Inputs::Snmptrap do
     before { @event = input.send :process_trap, trap }
 
     it "extract snmp payload" do
+      expect( @event.get('message') ).to be_a String # #<SNMP::SNMPv1_Trap:0x664c6bbc @enterprise=[1.3.6.1.4.1.9] ... >
+
       expect( @event.get('1.3.6.1.2.3.4') ).to eql '111'
     end
 
@@ -58,6 +60,8 @@ describe LogStash::Inputs::Snmptrap do
     before { @event = input.send :process_trap, trap }
 
     it "extract snmp payload" do
+      expect( @event.get('message') ).to be_a String
+
       expect( @event.get('1.2.3') ).to eql 'Null'
       expect( @event.get('1.3.6.1.2.1.1.3.0') ).to eql '00:00:10.11' # uptime tick
     end

--- a/spec/inputs/snmptrap_spec.rb
+++ b/spec/inputs/snmptrap_spec.rb
@@ -1,8 +1,9 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/devutils/rspec/shared_examples"
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 require 'logstash/inputs/snmptrap'
 
-describe LogStash::Inputs::Snmptrap do
+describe LogStash::Inputs::Snmptrap, :ecs_compatibility_support do
 
   it_behaves_like "an interruptible input plugin" do
     # as there is no mocking the run method will
@@ -19,57 +20,92 @@ describe LogStash::Inputs::Snmptrap do
   let(:source_ip) { '192.168.1.11' }
 
   let(:snmp_manager) do
-    manager = SNMP::Manager.new(:host => 'localhost', :port => 1061)
-    def manager.send_request(trap, community, host, port)
-      trap
+    SNMP::Manager.new.tap do |manager|
+      def manager.send_request(trap, community, host, port)
+        trap # dummy manager - we're just using the Manager API to create traps
+      end
     end
-    manager
   end
 
-  context 'v1' do
+  ecs_compatibility_matrix(:disabled, :v1, :v8) do |ecs_select|
 
-    let(:trap) do
-      trap = snmp_manager.trap_v1("enterprises.9", "10.1.2.3", :enterpriseSpecific, 42, 12345,
-                                  [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(111))])
-      trap.source_ip = source_ip
-      trap
+    let(:config) { super().merge 'ecs_compatibility' => ecs_compatibility }
+
+    context 'v1' do
+
+      let(:trap) do
+        trap = snmp_manager.trap_v1("enterprises.9", "10.1.2.3", :enterpriseSpecific, 42, 12345,
+                                    [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(111))])
+        trap.source_ip = source_ip
+        trap
+      end
+
+      before { @event = input.send :process_trap, trap }
+
+      it "extract snmp payload" do
+        expect( @event.get('message') ).to be_a String # #<SNMP::SNMPv1_Trap:0x664c6bbc @enterprise=[1.3.6.1.4.1.9] ... >
+        expect( @event.get('1.3.6.1.2.3.4') ).to eql '111'
+      end
+
+      it "sets source host" do
+        if ecs_select.active_mode == :disabled
+          expect( @event.get('host') ).to eql source_ip
+        else
+          expect( @event.get('host') ).to eql 'ip' => source_ip
+        end
+      end
+
     end
 
-    before { @event = input.send :process_trap, trap }
+    context 'v2' do
 
-    it "extract snmp payload" do
-      expect( @event.get('message') ).to be_a String # #<SNMP::SNMPv1_Trap:0x664c6bbc @enterprise=[1.3.6.1.4.1.9] ... >
+      let(:trap) do
+        trap = snmp_manager.trap_v2(1011, "1.3.6.1.2.1.1.1.0", ["1.2.3", "1.4.5.6"])
+        trap.source_ip = source_ip
+        trap
+      end
 
-      expect( @event.get('1.3.6.1.2.3.4') ).to eql '111'
-    end
+      before { @event = input.send :process_trap, trap }
 
-    it "sets source host" do
-      expect( @event.get('host') ).to eql '192.168.1.11'
+      it "extract snmp payload" do
+        expect( @event.get('message') ).to be_a String
+
+        expect( @event.get('1.2.3') ).to eql 'Null'
+        expect( @event.get('1.3.6.1.2.1.1.3.0') ).to eql '00:00:10.11' # uptime tick
+      end
+
+      it "sets source host" do
+        if ecs_select.active_mode == :disabled
+          expect( @event.get('host') ).to eql source_ip
+        else
+          expect( @event.get('host') ).to eql 'ip' => source_ip
+        end
+      end
+
+      context 'with target' do
+
+        let(:config) { super().merge 'target' => '[snmp]' }
+
+        it "extract snmp payload" do
+          expect( @event.include?('1.2.3') ).to be false
+          expect( @event.include?('1.3.6.1.2.1.1.3.0') ).to be false
+          expect( @event.get('[snmp][1.2.3]') ).to eql 'Null'
+          expect( @event.get('[snmp][1.3.6.1.2.1.1.3.0]') ).to eql '00:00:10.11' # uptime tick
+
+          expect( @event.get('message') ).to be_a String
+        end
+
+        it "sets source host" do
+          if ecs_select.active_mode == :disabled
+            expect( @event.get('host') ).to eql source_ip
+          else
+            expect( @event.get('host') ).to eql 'ip' => source_ip
+          end
+        end
+
+      end
+
     end
 
   end
-
-  context 'v2' do
-
-    let(:trap) do
-      trap = snmp_manager.trap_v2(1011, "1.3.6.1.2.1.1.1.0", ["1.2.3", "1.4.5.6"])
-      trap.source_ip = '192.168.1.11'
-      trap
-    end
-
-    before { @event = input.send :process_trap, trap }
-
-    it "extract snmp payload" do
-      expect( @event.get('message') ).to be_a String
-
-      expect( @event.get('1.2.3') ).to eql 'Null'
-      expect( @event.get('1.3.6.1.2.1.1.3.0') ).to eql '00:00:10.11' # uptime tick
-    end
-
-    it "sets source host" do
-      expect( @event.get('host') ).to eql '192.168.1.11'
-    end
-
-  end
-
 end

--- a/spec/inputs/snmptrap_spec.rb
+++ b/spec/inputs/snmptrap_spec.rb
@@ -57,7 +57,7 @@ describe LogStash::Inputs::Snmptrap, :ecs_compatibility_support do
 
     end
 
-    context 'v2' do
+    context 'with an SNMP v2 trap' do
 
       let(:trap) do
         trap = snmp_manager.trap_v2(1011, "1.3.6.1.2.1.1.1.0", ["1.2.3", "1.4.5.6"])

--- a/spec/inputs/snmptrap_spec.rb
+++ b/spec/inputs/snmptrap_spec.rb
@@ -31,7 +31,7 @@ describe LogStash::Inputs::Snmptrap, :ecs_compatibility_support do
 
     let(:config) { super().merge 'ecs_compatibility' => ecs_compatibility }
 
-    context 'v1' do
+    context 'with an SNMP v1 trap' do
 
       let(:trap) do
         trap = snmp_manager.trap_v1("enterprises.9", "10.1.2.3", :enterpriseSpecific, 42, 12345,


### PR DESCRIPTION
The PR's goal is to avoid schema conflicts, since the plugin sets the `host` field, in a non ECS compatible way.

To aid plugin users to better isolate SNMP payload data the plugin supports an optional `target`.
Also, the plugin was not using Logstash's `recent event_factory` support.
